### PR TITLE
SOLR configuration and Avoiding installing AWSCLI too many times

### DIFF
--- a/nodes/share-51.json
+++ b/nodes/share-51.json
@@ -84,5 +84,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "artifact-deployer::default", "alfresco::apply-amps", "alfresco::share", "alfresco::haproxy", "alfresco::redeploy"]
+    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::apply-amps", "alfresco::share", "alfresco::haproxy", "alfresco::redeploy"]
 }

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -50,6 +50,9 @@
       }
     },
     "artifacts" : {
+         "ssl-db-creds" :{
+            "enabled": true
+        },
         "alfresco-s3-connector" : {
             "enabled" : true,
             "path" : "/root/alfresco-s3-connector.amp",

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -67,5 +67,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::solr" ,"alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
+    "run_list": ["commons::ec2-tagging", "alfresco::solr", "commons::artifact-deployer" ,"alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
 }

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -12,6 +12,7 @@
         "log.json.enabled" : false,
         "components" : ["repo","solr"],
         "ssl_enabled" : false,
+        "generate.solr.core.config" : true,
         "properties" : {
             "dir.root" : "/usr/share/tomcat/alf_data",
             "alfresco.cluster.enabled" : false,
@@ -35,7 +36,11 @@
             "xmx_ratio" : 0.50
         },
         "workspace-solrproperties" : {
-            "alfresco.corePoolSize" : 4
+            "alfresco.corePoolSize" : 4,
+            "alfresco.port" : "8070"
+        },
+        "archive-solrproperties" : {
+            "alfresco.port" : "8070"
         }
     },
     "tomcat" : {
@@ -62,5 +67,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
+    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::solr" ,"alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
 }

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -26,7 +26,6 @@
             "s3.bucketName" : "@@CONTENTSTORE_S3_BUCKET@@",
             "s3.bucketLocation" : "@@AWS_REGION@@",
             "solr.port" : "8090",
-            "alfresco.port": "8070",
             "alfresco_user_store.adminpassword" : "@@ALFRESCO_PASSWORD@@"
         },
         "repo_tomcat_instance" : {

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -67,5 +67,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "alfresco::solr", "commons::artifact-deployer" ,"alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
+    "run_list": ["commons::ec2-tagging", "alfresco::solr-config", "commons::artifact-deployer" ,"alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
 }

--- a/nodes/solr-51.json
+++ b/nodes/solr-51.json
@@ -59,5 +59,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "artifact-deployer::default", "alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
+    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::repo", "alfresco::apply-amps", "alfresco::redeploy"]
 }


### PR DESCRIPTION
- artifact-deployer has been moved to a different cookbook. The original one was installing awscli as default, even if it was not necessary. Plus, the method to install it was quite old.
- now the solr configuration is moved to contextual properties, and turned on the flag "generate.ssl.core.config" to true. Still, this is not the optimal solution, all properties should stay in one place.
  Need refactor after we finish this task
